### PR TITLE
Fix import to support Tomcat and Jetty newest versions.

### DIFF
--- a/src/main/webapp/lessons/GoatHillsFinancial/GoatHillsFinancial.jsp
+++ b/src/main/webapp/lessons/GoatHillsFinancial/GoatHillsFinancial.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=ISO-8859-1" language="java" 
 	import="org.owasp.webgoat.session.*" 
 	errorPage="" %>
-<%@page import="org.owasp.webgoat.lessons.GoatHillsFinancial.GoatHillsFinancial;"%>
+<%@page import="org.owasp.webgoat.lessons.GoatHillsFinancial.GoatHillsFinancial"%>
 <style>
 <jsp:include page="GoatHillsFinancial.css" />
 </style>


### PR DESCRIPTION
Ref: https://discuss.zendesk.com/hc/en-us/articles/206211847-Upgrade-to-Tomcat-7-0-57-and-8-0-15-or-Later-may-Cause-JSP-Compilation-Error-HTTP-Status-500-Unable-to-compile-class-for-JSP-on-JSP-Page
